### PR TITLE
chore: bump third-party GH Actions to Node 24-compatible releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - run: uv python install 3.12
 
@@ -105,7 +105,7 @@ jobs:
           sha256sum * > "checksums-${VERSION}.txt"
           cat "checksums-${VERSION}.txt"
 
-      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: artifacts/*
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}


### PR DESCRIPTION
Third-party sweep ahead of GitHub's Node 24 transition. The previous sweep covered the `actions/*` namespace; this one covers third-party actions that still ran on Node 20 (or older). Latest `gh api action.yml` runtime confirmed for each target version.

**Bumps:**
- `astral-sh/setup-uv` v3 → v8.1.0
- `softprops/action-gh-release` v2 → v3.0.0

**Files:**
- `.github/workflows/release-binaries.yml`

**Runtime audit (current pin → target pin):**
- `softprops/action-gh-release` v1 (Node 16!) / v2.x (Node 20) → v3.0.0 (Node 24)
- `astral-sh/setup-uv` v3 (Node 16!) / v5.x (Node 20) → v8.1.0 (Node 24)
- `pnpm/action-setup` v3 / v4 (Node 20) → v6.0.8 (Node 24)
- `docker/login-action` v3 (Node 20) → v4.2.0 (Node 24)
- `docker/build-push-action` v6 (Node 20) → v7.2.0 (Node 24)
- `docker/setup-buildx-action` v3 (Node 20) → v4.1.0 (Node 24)
- `docker/setup-qemu-action` v3.x (Node 20) → v4.0.0 (Node 24)
- `docker/metadata-action` v5 (Node 20) → v6.1.0 (Node 24)

Only the action versions you have pinned are bumped — `pnpm/action-setup@v5`, `docker/login-action@v4*`, etc. already run on Node 24 and are left alone.

**SHA + version-comment pinning convention preserved.** All pins remain hard-pinned to commit SHA with `# vX.Y.Z` comment, matching the org's supply-chain hardening style.
