### PR TITLE
feat: NFT minting module (nfts track) — first KB-sourced module

### DIFF
--- a/modules/nft_minting_101.md
+++ b/modules/nft_minting_101.md
@@ -1,0 +1,75 @@
+---
+id: nft_minting_101
+title: "NFT Minting 101: Your First Game Asset"
+track: nfts
+summary: Mint an NFToken on the XRPL and verify you own it — your first on-ledger game asset.
+order: 20
+time: 15-20 min
+level: beginner
+mode: testnet
+requires: []
+produces:
+  - txid
+  - report
+checks:
+  - "NFToken minted (txid produced)"
+  - "NFTokenID captured from the mint"
+  - "Ownership verified on-ledger: issuer, taxon, transferable"
+---
+
+On the XRPL an NFT is a **native ledger object** — no smart contract required. The
+`NFTokenMint` transaction creates one and assigns it to your account, locking in its
+permanent properties: a collection id (taxon), an optional metadata URI, a royalty
+(TransferFee), and flags like *transferable*. This is the single entry point for putting
+a game asset on the ledger.
+
+Everything here runs on the testnet — free, disposable, and safe to repeat.
+
+## Step 1: Ensure your wallet is ready
+
+You need a funded wallet to mint. If you completed an earlier module it loads automatically.
+
+<!-- action: ensure_wallet -->
+
+## Step 2: Fund your wallet
+
+Minting costs a small fee plus an owner reserve (NFTs are stored in NFTokenPage objects
+holding up to 32 each; each page costs reserve on mainnet — free on testnet).
+
+<!-- action: ensure_funded -->
+
+## Step 3: Mint your game asset
+
+Now the core operation. You will mint a **transferable** NFToken with a metadata URI and
+a collection taxon. The `transfer_fee` sets a secondary-sale royalty (in 0.001% steps) —
+it only takes effect because the NFT is transferable.
+
+Permanent-once-minted: flags and TransferFee can **never** change after this, and the URI
+is stored as hex and is not validated — so pin your metadata somewhere durable.
+
+<!-- action: mint_nft uri="ipfs://bafy-example/sword-of-dawn.json" taxon=7 transfer_fee=500 transferable=true -->
+
+## Step 4: Verify you own it
+
+Read the NFT back from the ledger via `account_nfts`. You should see your new NFTokenID,
+the issuer (you), the taxon (collection id 7), and that it is transferable.
+
+<!-- action: verify_nft -->
+
+## Checkpoint: What you proved
+
+You minted a native NFT and verified ownership on-ledger:
+
+1. **NFTokenMint** — created an NFT with permanent properties in one transaction
+2. **Collection identity** — the (issuer, taxon) pair is how the XRPL groups a collection; there is no native "collection" object
+3. **Royalties** — TransferFee enforces a creator royalty at the protocol level
+4. **Verified** — `account_nfts` shows you as the owner
+
+Key concepts to remember:
+
+- **Permanent at mint**: flags + TransferFee can't change later — use mutable-URI / dynamic NFTs (XLS-46) if the asset must evolve (e.g. leveling gear)
+- **Reserve cost**: each NFTokenPage (up to 32 NFTs) costs owner reserve on mainnet
+- **Fungible game items belong in MPTs, not NFTs** — reserve NFTs for genuinely unique assets
+- **URI is unvalidated hex** — pin metadata to IPFS/Arweave so the link doesn't die
+
+Run `xrpl-lab proof-pack` when you're ready to export your work.

--- a/tests/test_nft.py
+++ b/tests/test_nft.py
@@ -1,0 +1,82 @@
+"""Tests for NFT transport, actions, and the nft_minting_101 module."""
+
+from pathlib import Path
+
+import pytest
+
+from xrpl_lab.actions.nft import get_account_nfts, mint_nft, verify_nft
+from xrpl_lab.linter import lint_module_file
+from xrpl_lab.transport.dry_run import DryRunTransport
+
+
+@pytest.fixture
+def transport():
+    return DryRunTransport()
+
+
+class TestNFTTransport:
+    @pytest.mark.asyncio
+    async def test_mint_success(self, transport):
+        result = await transport.submit_nft_mint(
+            "sFAKE", "ipfs://x", taxon=7, transfer_fee=500
+        )
+        assert result.success is True
+        assert result.result_code == "tesSUCCESS"
+        assert result.txid != ""
+        assert result.nft_id != ""
+
+    @pytest.mark.asyncio
+    async def test_mint_fail(self, transport):
+        transport.set_fail_next()
+        result = await transport.submit_nft_mint("sFAKE", "ipfs://x")
+        assert result.success is False
+        assert result.nft_id == ""
+
+    @pytest.mark.asyncio
+    async def test_minted_nft_tracked(self, transport):
+        r = await transport.submit_nft_mint("sFAKE", "ipfs://sword.json", taxon=7)
+        nfts = await transport.get_account_nfts("rANY")
+        assert len(nfts) == 1
+        assert nfts[0].nft_id == r.nft_id
+        assert nfts[0].taxon == 7
+        assert nfts[0].uri == "ipfs://sword.json"
+        assert nfts[0].flags & 0x8  # tfTransferable
+
+
+class TestNFTActions:
+    @pytest.mark.asyncio
+    async def test_mint_and_verify(self, transport):
+        r = await mint_nft(transport, "sFAKE", "ipfs://sword.json", taxon=7, transfer_fee=500)
+        assert r.success and r.nft_id
+        v = await verify_nft(transport, "rANY", expected_nft_id=r.nft_id)
+        assert v.found
+        assert v.passed
+        assert v.nft is not None and v.nft.nft_id == r.nft_id
+
+    @pytest.mark.asyncio
+    async def test_verify_no_nfts(self, transport):
+        v = await verify_nft(transport, "rEMPTY")
+        assert v.found is False
+        assert not v.passed
+        assert "No NFTokens" in v.failures[0]
+
+    @pytest.mark.asyncio
+    async def test_verify_taxon_mismatch(self, transport):
+        r = await mint_nft(transport, "sFAKE", "ipfs://x", taxon=7)
+        v = await verify_nft(
+            transport, "rANY", expected_nft_id=r.nft_id, expected_taxon=9
+        )
+        assert not v.passed
+        assert any("Taxon mismatch" in f for f in v.failures)
+
+    @pytest.mark.asyncio
+    async def test_get_account_nfts_empty(self, transport):
+        assert await get_account_nfts(transport, "rEMPTY") == []
+
+
+class TestNFTModule:
+    def test_module_lints_clean(self):
+        path = Path(__file__).parent.parent / "modules" / "nft_minting_101.md"
+        issues = lint_module_file(path)
+        errors = [i for i in issues if i.level == "error"]
+        assert not errors, f"lint errors: {[str(i) for i in errors]}"

--- a/xrpl_lab/actions/nft.py
+++ b/xrpl_lab/actions/nft.py
@@ -1,0 +1,84 @@
+"""NFT actions — mint an NFToken (a game asset) and verify ownership on-ledger."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..transport.base import NFTInfo, SubmitResult, Transport
+
+
+async def mint_nft(
+    transport: Transport,
+    wallet_seed: str,
+    uri: str,
+    taxon: int = 0,
+    transfer_fee: int = 0,
+    transferable: bool = True,
+) -> SubmitResult:
+    """Mint an NFToken on the ledger. Returns SubmitResult with nft_id set on success."""
+    return await transport.submit_nft_mint(
+        wallet_seed=wallet_seed,
+        uri=uri,
+        taxon=taxon,
+        transfer_fee=transfer_fee,
+        transferable=transferable,
+    )
+
+
+async def get_account_nfts(transport: Transport, address: str) -> list[NFTInfo]:
+    """List NFTokens owned by an address."""
+    return await transport.get_account_nfts(address)
+
+
+@dataclass
+class NFTVerifyResult:
+    """Result of verifying NFT ownership on-ledger."""
+
+    found: bool
+    nft: NFTInfo | None
+    checks: list[str]
+    failures: list[str]
+
+    @property
+    def passed(self) -> bool:
+        return len(self.failures) == 0
+
+
+async def verify_nft(
+    transport: Transport,
+    address: str,
+    expected_nft_id: str | None = None,
+    expected_taxon: int | None = None,
+) -> NFTVerifyResult:
+    """Verify an NFT is owned by *address*, optionally matching a specific NFTokenID / taxon."""
+    nfts = await transport.get_account_nfts(address)
+    checks: list[str] = []
+    failures: list[str] = []
+
+    if not nfts:
+        failures.append("No NFTokens found for this account")
+        return NFTVerifyResult(found=False, nft=None, checks=checks, failures=failures)
+
+    if expected_nft_id:
+        match = next((n for n in nfts if n.nft_id == expected_nft_id), None)
+        if match is None:
+            failures.append(
+                f"NFToken {expected_nft_id[:16]}... not found among {len(nfts)} owned"
+            )
+            return NFTVerifyResult(found=False, nft=None, checks=checks, failures=failures)
+    else:
+        match = nfts[-1]  # most recently minted
+
+    checks.append(f"NFToken found: {match.nft_id[:24]}...")
+    checks.append(f"Issuer: {match.issuer}")
+    checks.append(f"Taxon (collection id): {match.taxon}")
+    if match.uri:
+        checks.append(f"URI: {match.uri}")
+    checks.append(f"Transferable: {'yes' if match.flags & 0x8 else 'no'}")
+    if match.transfer_fee:
+        checks.append(f"Royalty (TransferFee): {match.transfer_fee / 1000:.3f}%")
+
+    if expected_taxon is not None and match.taxon != expected_taxon:
+        failures.append(f"Taxon mismatch: expected {expected_taxon}, got {match.taxon}")
+
+    return NFTVerifyResult(found=True, nft=match, checks=checks, failures=failures)

--- a/xrpl_lab/curriculum.py
+++ b/xrpl_lab/curriculum.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from .modules import ModuleDef
 
 # Canonical tracks in display order.
-TRACKS = ("foundations", "dex", "reserves", "audit", "amm")
+TRACKS = ("foundations", "nfts", "dex", "reserves", "audit", "amm")
 
 # Canonical levels in progression order.
 LEVELS = ("beginner", "intermediate", "advanced")

--- a/xrpl_lab/handlers.py
+++ b/xrpl_lab/handlers.py
@@ -28,6 +28,7 @@ from .actions.dex import (
     verify_offer_absent,
     verify_offer_present,
 )
+from .actions.nft import mint_nft, verify_nft
 from .actions.reserves import (
     _drops_to_xrp,
     compare_snapshots,
@@ -1659,6 +1660,84 @@ async def handle_write_report(
     return context
 
 
+async def handle_mint_nft(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    args = step.action_args
+    uri = args.get("uri", "ipfs://example/game-asset.json")
+    try:
+        taxon = int(args.get("taxon", "0"))
+    except ValueError:
+        taxon = 0
+    try:
+        transfer_fee = int(args.get("transfer_fee", "0"))
+    except ValueError:
+        transfer_fee = 0
+    transferable = str(args.get("transferable", "true")).lower() != "false"
+
+    if "wallet_seed" not in context:
+        console.print("  [red]No wallet in context. Run the wallet step first.[/]")
+        return context
+    seed = context["wallet_seed"].get()
+
+    console.print(
+        f"  Minting NFToken — taxon [cyan]{taxon}[/], "
+        f"transferable [cyan]{transferable}[/], uri [cyan]{uri}[/]"
+    )
+    if transfer_fee:
+        console.print(f"  Royalty (TransferFee): {transfer_fee / 1000:.3f}%")
+    result = await mint_nft(transport, seed, uri, taxon, transfer_fee, transferable)
+
+    if result.success:
+        console.print("  [green]NFToken minted![/]")
+        console.print(f"  TXID: [cyan]{result.txid}[/]")
+        if result.nft_id:
+            console.print(f"  NFTokenID: [cyan]{result.nft_id}[/]")
+            context["nft_id"] = result.nft_id
+        if result.explorer_url:
+            console.print(f"  Explorer: [blue]{result.explorer_url}[/]")
+        state.record_tx(
+            txid=result.txid,
+            module_id=context.get("module_id", ""),
+            network=state.network,
+            success=True,
+            explorer_url=result.explorer_url,
+        )
+        context.setdefault("txids", []).append(result.txid)
+    else:
+        console.print(f"  [red]Mint failed: {result.error}[/]")
+        state.record_tx(
+            txid=result.txid or "failed",
+            module_id=context.get("module_id", ""),
+            network=state.network,
+            success=False,
+        )
+    save_state(state)
+    return context
+
+
+async def handle_verify_nft(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    address = state.wallet_address or ""
+    if not address:
+        console.print("  [red]No wallet address. Run the wallet step first.[/]")
+        return context
+
+    expected = context.get("nft_id")
+    result = await verify_nft(transport, address, expected_nft_id=expected)
+    for c in result.checks:
+        console.print(f"  [green]{c}[/]")
+    for f in result.failures:
+        console.print(f"  [red]{f}[/]")
+    if result.found and result.passed:
+        console.print("  [green]NFT ownership verified on-ledger.[/]")
+    context["last_nft_verify"] = result
+    return context
+
+
 # ---------------------------------------------------------------------------
 # Registration — populate the registry
 # ---------------------------------------------------------------------------
@@ -1702,6 +1781,27 @@ def _register_all() -> None:
             name="verify_tx",
             handler=handle_verify_tx,
             description="Verify the last transaction on-ledger",
+        ),
+        ActionDef(
+            name="mint_nft",
+            handler=handle_mint_nft,
+            description="Mint an NFToken (a game asset)",
+            wallet_required=True,
+            payload_fields=[
+                PayloadField(name="uri", default="ipfs://example/game-asset.json",
+                             description="Metadata URI for the asset"),
+                PayloadField(name="taxon", type="int", default="0",
+                             description="Collection id (issuer+taxon = collection)"),
+                PayloadField(name="transfer_fee", type="int", default="0",
+                             description="Royalty 0-50000 (0.001% steps); needs transferable"),
+                PayloadField(name="transferable", type="bool", default="true",
+                             description="Whether the NFT can be traded"),
+            ],
+        ),
+        ActionDef(
+            name="verify_nft",
+            handler=handle_verify_nft,
+            description="Verify NFToken ownership on-ledger",
         ),
         ActionDef(
             name="create_issuer_wallet",

--- a/xrpl_lab/transport/base.py
+++ b/xrpl_lab/transport/base.py
@@ -48,6 +48,7 @@ class SubmitResult:
     ledger_index: int | None = None
     error: str = ""
     explorer_url: str = ""
+    nft_id: str = ""  # NFTokenID, set on a successful NFTokenMint
 
 
 @dataclass
@@ -76,6 +77,19 @@ class TrustLineInfo:
     currency: str
     balance: str = "0"
     limit: str = "0"
+
+
+@dataclass
+class NFTInfo:
+    """A single NFToken owned by an account."""
+
+    nft_id: str
+    issuer: str = ""
+    taxon: int = 0
+    uri: str = ""  # decoded UTF-8 if possible, else hex
+    flags: int = 0
+    transfer_fee: int = 0
+    serial: int = 0
 
 
 @dataclass
@@ -264,3 +278,18 @@ class Transport(ABC):
         lp_token_issuer: str,
     ) -> str:
         """Get LP token balance for an address. Returns '0' if none."""
+
+    @abstractmethod
+    async def submit_nft_mint(
+        self,
+        wallet_seed: str,
+        uri: str,
+        taxon: int = 0,
+        transfer_fee: int = 0,
+        transferable: bool = True,
+    ) -> SubmitResult:
+        """Mint an NFToken (NFTokenMint). Returns SubmitResult with nft_id set on success."""
+
+    @abstractmethod
+    async def get_account_nfts(self, address: str) -> list[NFTInfo]:
+        """List NFTokens owned by an address (account_nfts)."""

--- a/xrpl_lab/transport/dry_run.py
+++ b/xrpl_lab/transport/dry_run.py
@@ -11,6 +11,7 @@ from .base import (
     AmmInfo,
     FundResult,
     NetworkInfo,
+    NFTInfo,
     OfferInfo,
     SubmitResult,
     Transport,
@@ -95,6 +96,8 @@ class DryRunTransport(Transport):
         # AMM state
         self._amm_pools: dict[str, dict] = {}  # pair_key -> pool state
         self._lp_balances: dict[str, dict[str, str]] = {}  # address -> {lp_key: balance}
+        # NFT state — minted NFTokens per owner address
+        self._nfts: _PerAddressStore = _PerAddressStore()
 
     def _next_txid(self) -> str:
         """Generate a unique deterministic transaction ID (per-instance counter)."""
@@ -857,3 +860,62 @@ class DryRunTransport(Transport):
         lp_key = f"{lp_token_currency}/{lp_token_issuer}"
         balances = self._lp_balances.get(address, {})
         return balances.get(lp_key, "0")
+
+    # ── NFT methods ──────────────────────────────────────────────────
+
+    async def submit_nft_mint(
+        self,
+        wallet_seed: str,
+        uri: str,
+        taxon: int = 0,
+        transfer_fee: int = 0,
+        transferable: bool = True,
+    ) -> SubmitResult:
+        if self._fail_next:
+            self._fail_next = False
+            return SubmitResult(
+                success=False,
+                result_code="temINVALID_FLAG",
+                fee="12",
+                error="[dry-run] Simulated failure: invalid NFTokenMint",
+            )
+
+        owner = _address_from_seed(wallet_seed)
+        txid = self._next_txid()
+        nft_id = hashlib.sha256(
+            f"{owner}-{uri}-{taxon}-{self._counter}".encode()
+        ).hexdigest().upper()[:64]
+        owned = self._nfts.setdefault(owner, [])
+        owned.append(
+            NFTInfo(
+                nft_id=nft_id,
+                issuer=owner,
+                taxon=taxon,
+                uri=uri,
+                flags=0x8 if transferable else 0,
+                transfer_fee=transfer_fee,
+                serial=len(owned) + 1,
+            )
+        )
+        self._owner_count += 1
+        return SubmitResult(
+            success=True,
+            txid=txid,
+            result_code="tesSUCCESS",
+            fee="12",
+            ledger_index=99999999,
+            explorer_url="",  # dry-run tx is simulated — no public explorer
+            nft_id=nft_id,
+        )
+
+    async def get_account_nfts(self, address: str) -> list[NFTInfo]:
+        if address in self._nfts:
+            return list(self._nfts[address])
+        legacy = self._nfts.get(_PerAddressStore._LEGACY_KEY, [])
+        if legacy:
+            return list(legacy)
+        real = {k: v for k, v in self._nfts.items()
+                if k != _PerAddressStore._LEGACY_KEY}
+        if len(real) == 1:
+            return list(next(iter(real.values())))
+        return []

--- a/xrpl_lab/transport/xrpl_testnet.py
+++ b/xrpl_lab/transport/xrpl_testnet.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from contextlib import asynccontextmanager
 from decimal import Decimal, InvalidOperation
 from urllib.parse import urlparse
 
@@ -204,6 +205,18 @@ def _friendly_error(exc: Exception) -> str:
     return msg
 
 
+@asynccontextmanager
+async def _rpc_client(rpc_url: str):
+    """Async-context wrapper around AsyncJsonRpcClient.
+
+    The JSON-RPC client is stateless and — as of xrpl-py 4.5.0 — is NOT itself an
+    async context manager (no ``__aenter__``). This wrapper keeps the existing
+    ``async with ... as client:`` call sites correct on xrpl-py 4.x; there is
+    nothing to clean up on exit.
+    """
+    yield AsyncJsonRpcClient(rpc_url)
+
+
 class XRPLTestnetTransport(Transport):
     """Real XRPL Testnet transport using xrpl-py async client."""
 
@@ -257,7 +270,7 @@ class XRPLTestnetTransport(Transport):
     async def get_network_info(self) -> NetworkInfo:
         network = classify_network(self._rpc_url)
         try:
-            async with AsyncJsonRpcClient(self._rpc_url) as client:
+            async with _rpc_client(self._rpc_url) as client:
                 ledger_idx = await asyncio.wait_for(
                     get_latest_validated_ledger_sequence(client),
                     timeout=RPC_TIMEOUT,
@@ -402,7 +415,7 @@ class XRPLTestnetTransport(Transport):
                     amount=xrp_to_drops(amount_f),  # xrp_to_drops accepts Decimal
                     memos=_memo_field(memo) or None,
                 )
-                async with AsyncJsonRpcClient(self._rpc_url) as client:
+                async with _rpc_client(self._rpc_url) as client:
                     response = await asyncio.wait_for(
                         submit_and_wait(payment, client, wallet),
                         timeout=SUBMIT_TIMEOUT,
@@ -495,7 +508,7 @@ class XRPLTestnetTransport(Transport):
                         value=limit,
                     ),
                 )
-                async with AsyncJsonRpcClient(self._rpc_url) as client:
+                async with _rpc_client(self._rpc_url) as client:
                     response = await asyncio.wait_for(
                         submit_and_wait(trust_set, client, wallet),
                         timeout=SUBMIT_TIMEOUT,
@@ -590,7 +603,7 @@ class XRPLTestnetTransport(Transport):
                     ),
                     memos=_memo_field(memo) or None,
                 )
-                async with AsyncJsonRpcClient(self._rpc_url) as client:
+                async with _rpc_client(self._rpc_url) as client:
                     response = await asyncio.wait_for(
                         submit_and_wait(payment, client, wallet),
                         timeout=SUBMIT_TIMEOUT,
@@ -659,7 +672,7 @@ class XRPLTestnetTransport(Transport):
 
     async def get_trust_lines(self, address: str) -> list[TrustLineInfo]:
         try:
-            async with AsyncJsonRpcClient(self._rpc_url) as client:
+            async with _rpc_client(self._rpc_url) as client:
                 response = await asyncio.wait_for(
                     client.request(
                         AccountLines(account=address, ledger_index="validated")
@@ -704,7 +717,7 @@ class XRPLTestnetTransport(Transport):
                     transfer_fee=transfer_fee or None,
                     flags=8 if transferable else 0,  # tfTransferable = 0x8
                 )
-                async with AsyncJsonRpcClient(self._rpc_url) as client:
+                async with _rpc_client(self._rpc_url) as client:
                     response = await asyncio.wait_for(
                         submit_and_wait(mint, client, wallet),
                         timeout=SUBMIT_TIMEOUT,
@@ -764,7 +777,7 @@ class XRPLTestnetTransport(Transport):
 
     async def get_account_nfts(self, address: str) -> list[NFTInfo]:
         try:
-            async with AsyncJsonRpcClient(self._rpc_url) as client:
+            async with _rpc_client(self._rpc_url) as client:
                 response = await asyncio.wait_for(
                     client.request(
                         AccountNFTs(account=address, ledger_index="validated")
@@ -847,7 +860,7 @@ class XRPLTestnetTransport(Transport):
                         taker_gets_currency, taker_gets_value, taker_gets_issuer
                     ),
                 )
-                async with AsyncJsonRpcClient(self._rpc_url) as client:
+                async with _rpc_client(self._rpc_url) as client:
                     response = await asyncio.wait_for(
                         submit_and_wait(offer, client, wallet),
                         timeout=SUBMIT_TIMEOUT,
@@ -932,7 +945,7 @@ class XRPLTestnetTransport(Transport):
                     account=wallet.address,
                     offer_sequence=offer_sequence,
                 )
-                async with AsyncJsonRpcClient(self._rpc_url) as client:
+                async with _rpc_client(self._rpc_url) as client:
                     response = await asyncio.wait_for(
                         submit_and_wait(cancel, client, wallet),
                         timeout=SUBMIT_TIMEOUT,
@@ -1001,7 +1014,7 @@ class XRPLTestnetTransport(Transport):
 
     async def get_account_offers(self, address: str) -> list[OfferInfo]:
         try:
-            async with AsyncJsonRpcClient(self._rpc_url) as client:
+            async with _rpc_client(self._rpc_url) as client:
                 response = await asyncio.wait_for(
                     client.request(
                         AccountOffers(account=address, ledger_index="validated")
@@ -1024,7 +1037,7 @@ class XRPLTestnetTransport(Transport):
 
     async def get_account_info(self, address: str) -> AccountSnapshot:
         try:
-            async with AsyncJsonRpcClient(self._rpc_url) as client:
+            async with _rpc_client(self._rpc_url) as client:
                 response = await asyncio.wait_for(
                     client.request(
                         AccountInfo(account=address, ledger_index="validated")
@@ -1044,7 +1057,7 @@ class XRPLTestnetTransport(Transport):
 
     async def fetch_tx(self, txid: str) -> TxInfo:
         try:
-            async with AsyncJsonRpcClient(self._rpc_url) as client:
+            async with _rpc_client(self._rpc_url) as client:
                 response = await asyncio.wait_for(
                     client.request(Tx(transaction=txid)),
                     timeout=RPC_TIMEOUT,
@@ -1077,7 +1090,7 @@ class XRPLTestnetTransport(Transport):
 
     async def get_balance(self, address: str) -> str:
         try:
-            async with AsyncJsonRpcClient(self._rpc_url) as client:
+            async with _rpc_client(self._rpc_url) as client:
                 response = await asyncio.wait_for(
                     client.request(
                         AccountInfo(account=address, ledger_index="validated")

--- a/xrpl_lab/transport/xrpl_testnet.py
+++ b/xrpl_lab/transport/xrpl_testnet.py
@@ -14,16 +14,18 @@ from xrpl.asyncio.transaction import submit_and_wait
 from xrpl.models import (
     AccountInfo,
     AccountLines,
+    AccountNFTs,
     AccountOffers,
     IssuedCurrencyAmount,
     Memo,
+    NFTokenMint,
     OfferCancel,
     OfferCreate,
     Payment,
     TrustSet,
     Tx,
 )
-from xrpl.utils import drops_to_xrp, xrp_to_drops
+from xrpl.utils import drops_to_xrp, get_nftoken_id, hex_to_str, str_to_hex, xrp_to_drops
 from xrpl.wallet import Wallet
 
 from .base import (
@@ -31,6 +33,7 @@ from .base import (
     AmmInfo,
     FundResult,
     NetworkInfo,
+    NFTInfo,
     OfferInfo,
     SubmitResult,
     Transport,
@@ -676,6 +679,119 @@ class XRPLTestnetTransport(Transport):
             ]
         except Exception:
             logger.warning("get_trust_lines failed for %s", address, exc_info=True)
+            return []
+
+    async def submit_nft_mint(
+        self,
+        wallet_seed: str,
+        uri: str,
+        taxon: int = 0,
+        transfer_fee: int = 0,
+        transferable: bool = True,
+    ) -> SubmitResult:
+        guard = self._network_guard()
+        if guard is not None:
+            return SubmitResult(success=False, result_code="local_error", error=guard)
+
+        last_error = ""
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                wallet = Wallet.from_seed(wallet_seed)
+                mint = NFTokenMint(
+                    account=wallet.address,
+                    nftoken_taxon=taxon,
+                    uri=str_to_hex(uri) if uri else None,
+                    transfer_fee=transfer_fee or None,
+                    flags=8 if transferable else 0,  # tfTransferable = 0x8
+                )
+                async with AsyncJsonRpcClient(self._rpc_url) as client:
+                    response = await asyncio.wait_for(
+                        submit_and_wait(mint, client, wallet),
+                        timeout=SUBMIT_TIMEOUT,
+                    )
+
+                result = response.result
+                meta = result.get("meta", {})
+                result_code = meta.get(
+                    "TransactionResult", result.get("engine_result", "unknown")
+                )
+                txid = result.get("hash", "")
+                fee = result.get("Fee", "0")
+                ledger_idx = result.get("ledger_index") or meta.get("ledger_index")
+
+                success = result_code == "tesSUCCESS"
+                nft_id = ""
+                error_msg = ""
+                if success:
+                    try:
+                        nft_id = get_nftoken_id(meta)
+                    except Exception:
+                        nft_id = ""
+                else:
+                    from ..doctor import explain_result_code
+
+                    info = explain_result_code(result_code)
+                    error_msg = f"{info['meaning']}. {info['action']}"
+
+                return SubmitResult(
+                    success=success,
+                    txid=txid,
+                    result_code=result_code,
+                    fee=fee,
+                    ledger_index=ledger_idx,
+                    explorer_url=self._explorer_url(txid),
+                    error=error_msg,
+                    nft_id=nft_id,
+                )
+
+            except TimeoutError:
+                last_error = "NFTokenMint submission timed out. Try again in a minute."
+                if attempt < MAX_RETRIES:
+                    await asyncio.sleep(RETRY_DELAY)
+                    continue
+            except Exception as exc:
+                last_error = _friendly_error(exc)
+                if any(
+                    code in last_error
+                    for code in ("temBAD", "tefBAD", "Invalid", "malformed")
+                ):
+                    break
+                if attempt < MAX_RETRIES:
+                    await asyncio.sleep(RETRY_DELAY)
+                    continue
+
+        return SubmitResult(success=False, result_code="local_error", error=last_error)
+
+    async def get_account_nfts(self, address: str) -> list[NFTInfo]:
+        try:
+            async with AsyncJsonRpcClient(self._rpc_url) as client:
+                response = await asyncio.wait_for(
+                    client.request(
+                        AccountNFTs(account=address, ledger_index="validated")
+                    ),
+                    timeout=RPC_TIMEOUT,
+                )
+            out: list[NFTInfo] = []
+            for n in response.result.get("account_nfts", []):
+                uri_hex = n.get("URI", "") or ""
+                try:
+                    uri = hex_to_str(uri_hex) if uri_hex else ""
+                except Exception:
+                    uri = uri_hex
+                out.append(
+                    NFTInfo(
+                        nft_id=n.get("NFTokenID", ""),
+                        issuer=n.get("Issuer", address),
+                        taxon=int(n.get("NFTokenTaxon", 0)),
+                        uri=uri,
+                        flags=int(n.get("Flags", 0)),
+                        transfer_fee=int(n.get("TransferFee", 0)),
+                        serial=int(n.get("nft_serial", 0)),
+                    )
+                )
+            return out
+        except Exception:
+            logger.warning("get_account_nfts failed for %s", address, exc_info=True)
             return []
 
     def _amount_obj(


### PR DESCRIPTION
The first xrpl-lab module sourced from the **xrpl-knowledge** readouts database — proving the KB → workbook pipeline.

## What it adds
- New **`nfts` track** + `modules/nft_minting_101.md`: ensure wallet → fund → **mint a game asset** (NFTokenMint: taxon, URI, royalty, transferable) → **verify ownership** via `account_nfts`.
- Transport: `NFTInfo` + `SubmitResult.nft_id`; `submit_nft_mint` + `get_account_nfts` on the `Transport` ABC, implemented in **both** `DryRunTransport` (offline/deterministic) and `XRPLTestnetTransport` (real `NFTokenMint` via xrpl-py; NFTokenID parsed from tx meta).
- `actions/nft.py` (`mint_nft`/`verify_nft`) + handlers registered as actions `mint_nft` / `verify_nft`.
- `tests/test_nft.py` — 8 offline tests.

## Provenance
Seeded from the verified KB capability `nftokenmint` (mainnet-live, cross-family verified by deepseek-v3.1:671b). The lesson carries the KB's gotchas verbatim: permanent-at-mint, owner-reserve cost, *"fungible items belong in MPTs, not NFTs,"* URI durability.

## Verification
- Full suite: **793 passed, 23 skipped** (8 new).
- `ruff check` clean; module + curriculum lint clean; no dependency/lock changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)