### PR TITLE
feat: escrow, DID & MPT modules (payments/identity/tokens tracks)

### DIFF
--- a/modules/did_101.md
+++ b/modules/did_101.md
@@ -1,0 +1,64 @@
+---
+id: did_101
+title: "DID 101: On-Ledger Identity"
+track: identity
+summary: Anchor a Decentralized Identifier (XLS-40) to your account and verify it.
+order: 50
+time: 10-15 min
+level: intermediate
+mode: testnet
+requires: []
+produces:
+  - txid
+  - report
+checks:
+  - "DID set (txid produced)"
+  - "DID verified on-ledger: URI"
+---
+
+A **Decentralized Identifier (DID, XLS-40)** anchors a W3C-conformant identity to your XRPL
+account. The `DIDSet` transaction stores a small on-ledger record — typically a **URI pointing
+to an off-chain DID document** — that other apps can resolve to verify who controls the account.
+It's the foundation for player identity and credential-gated features.
+
+This runs on testnet — free and disposable.
+
+## Step 1: Ensure your wallet is ready
+
+<!-- action: ensure_wallet -->
+
+## Step 2: Fund your wallet
+
+Setting a DID costs a small fee plus an owner reserve for the DID object (free on testnet).
+
+<!-- action: ensure_funded -->
+
+## Step 3: Set your DID
+
+Anchor a DID URI to your account. In production this URI points to a DID document (hosted on
+IPFS/HTTPS) describing your keys and service endpoints.
+
+<!-- action: set_did uri="did:xrpl:1:example-player" -->
+
+## Step 4: Verify your DID
+
+Read it back via `account_objects`. You should see the DID object with your URI.
+
+<!-- action: verify_did -->
+
+## Checkpoint: What you proved
+
+You anchored a decentralized identifier to your account and verified it on-ledger:
+
+1. **DIDSet** — created an on-ledger DID record controlled by your account
+2. **Off-chain document** — the on-ledger anchor points to a richer DID document kept off-chain
+3. **Verified** — `account_objects` shows your DID
+
+Key concepts to remember:
+
+- **Anchor on-ledger, document off-ledger** — keep the DID document + any credentials off-chain (IPFS/STORJ/HTTPS); the ledger holds only the pointer.
+- **One DID per account** — `DIDSet` creates or updates it; `DIDDelete` removes it.
+- **PII stays off-ledger** — never put personal data on the public ledger; DIDs + Credentials (XLS-70) are designed to keep it private.
+- **Pairs with Credentials & Permissioned Domains** — DID is the identity anchor; credentials attest facts about it for KYC / region-gated features.
+
+Run `xrpl-lab proof-pack` when you're ready to export your work.

--- a/modules/escrow_101.md
+++ b/modules/escrow_101.md
@@ -1,0 +1,64 @@
+---
+id: escrow_101
+title: "Escrow 101: Time-Locked XRP"
+track: payments
+summary: Lock XRP in a time-based escrow and verify it on-ledger.
+order: 40
+time: 15-20 min
+level: intermediate
+mode: testnet
+requires: []
+produces:
+  - txid
+  - report
+checks:
+  - "Escrow created (txid produced)"
+  - "Escrow verified on-ledger: amount, destination, FinishAfter"
+---
+
+**Escrow** locks XRP on-ledger so it can only be released when a condition is met. The simplest
+form is **time-based**: set a `FinishAfter` time, and the funds can be finished (released) only
+after it. Escrow is the building block for vesting, delayed payouts, and conditional rewards.
+
+This runs on testnet — free and disposable. You'll escrow XRP to yourself, finishable shortly.
+
+## Step 1: Ensure your wallet is ready
+
+<!-- action: ensure_wallet -->
+
+## Step 2: Fund your wallet
+
+Escrow locks real XRP plus an owner reserve for the escrow object (free on testnet).
+
+<!-- action: ensure_funded -->
+
+## Step 3: Create a time-based escrow
+
+Lock some XRP with a `FinishAfter` a couple of minutes out. (Defaults escrow to your own
+account — escrow-to-self is the simplest way to learn the mechanics.)
+
+<!-- action: create_escrow amount=10 finish_seconds=120 -->
+
+## Step 4: Verify the escrow
+
+Read it back via `account_objects`. You should see the locked amount, destination, and the
+FinishAfter time.
+
+<!-- action: verify_escrow -->
+
+## Checkpoint: What you proved
+
+You locked XRP in a time-based escrow and verified it on-ledger:
+
+1. **EscrowCreate** — locked funds with a `FinishAfter` release time
+2. **On-ledger custody** — no third party holds the funds; the ledger enforces the condition
+3. **Verified** — `account_objects` shows your escrow
+
+Key concepts to remember:
+
+- **FinishAfter or a crypto-condition** — every escrow needs at least one; `CancelAfter` (if set) must be **later** than `FinishAfter`.
+- **Finishing is a second step** — `EscrowFinish` can only succeed **after** `FinishAfter`; this module creates + verifies, you finish later.
+- **Reserve cost** — each open escrow object costs owner reserve until finished or cancelled.
+- **Token escrow** — as of XLS-85 (2026), escrow also supports IOUs/MPTs (issuer opt-in); this lesson uses XRP.
+
+Run `xrpl-lab proof-pack` when you're ready to export your work.

--- a/modules/mpt_issuance_101.md
+++ b/modules/mpt_issuance_101.md
@@ -1,0 +1,66 @@
+---
+id: mpt_issuance_101
+title: "MPT Issuance 101: A Game Currency in One Transaction"
+track: tokens
+summary: Issue a Multi-Purpose Token (XLS-33) as a game currency and verify it on-ledger.
+order: 30
+time: 15-20 min
+level: intermediate
+mode: testnet
+requires: []
+produces:
+  - txid
+  - report
+checks:
+  - "MPT issuance created (txid produced)"
+  - "Issuance verified on-ledger: max supply, transferable"
+---
+
+A **Multi-Purpose Token (MPT, XLS-33)** is the modern way to issue a fungible token on the
+XRPL — perfect for an in-game soft currency. Unlike trust-line IOUs, MPTs need **no trust line
+per holder**, carry native metadata, and define their entire policy — supply cap, decimal scale,
+transfer fee, and capability flags — in a **single `MPTokenIssuanceCreate` transaction**.
+
+This runs on testnet — free and disposable.
+
+## Step 1: Ensure your wallet is ready
+
+You need a funded wallet to issue a token. If you completed an earlier module it loads automatically.
+
+<!-- action: ensure_wallet -->
+
+## Step 2: Fund your wallet
+
+Issuing an MPT costs a small fee plus an owner reserve for the issuance object (free on testnet).
+
+<!-- action: ensure_funded -->
+
+## Step 3: Issue your game currency
+
+Create an MPT issuance with a fixed maximum supply, an asset scale (decimal places), and the
+**transferable** flag so players can trade it. The policy you set here is largely immutable.
+
+<!-- action: create_mpt_issuance maximum_amount=1000000 asset_scale=2 transferable=true -->
+
+## Step 4: Verify the issuance
+
+Read it back from the ledger via `account_objects`. You should see your issuance id, the
+maximum supply, and that it is transferable.
+
+<!-- action: verify_mpt_issuance -->
+
+## Checkpoint: What you proved
+
+You issued a native fungible token in one transaction and verified it on-ledger:
+
+1. **MPTokenIssuanceCreate** — defined supply cap, scale, fee, and flags in a single tx
+2. **No trust lines** — holders opt in with one `MPTokenAuthorize`, not a per-token trust line
+3. **Verified** — `account_objects` shows the issuance you control
+
+Key concepts to remember:
+
+- **MPT vs IOU** — MPT is the right primitive for a *new* game soft currency (compact, trust-line-free). Use a trust-line **IOU** when you need a currency that's **tradeable on the DEX today** — MPT DEX trading (XLS-82) is **not yet live on mainnet**.
+- **Policy is set at creation** — supply cap, asset scale, and most flags can't change later; choose deliberately.
+- **Hard vs soft money** — pair a capped MPT (premium/hard currency) with an uncapped earned currency for a healthy economy.
+
+Run `xrpl-lab proof-pack` when you're ready to export your work.

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -1,0 +1,61 @@
+"""Tests for DID transport, actions, and the did_101 module."""
+
+from pathlib import Path
+
+import pytest
+
+from xrpl_lab.actions.did import set_did, verify_did
+from xrpl_lab.linter import lint_module_file
+from xrpl_lab.transport.dry_run import DryRunTransport
+
+
+@pytest.fixture
+def transport():
+    return DryRunTransport()
+
+
+class TestDIDTransport:
+    @pytest.mark.asyncio
+    async def test_set_success(self, transport):
+        r = await transport.submit_did_set("sFAKE", uri="did:xrpl:x")
+        assert r.success is True
+        assert r.txid != ""
+
+    @pytest.mark.asyncio
+    async def test_set_fail(self, transport):
+        transport.set_fail_next()
+        r = await transport.submit_did_set("sFAKE", uri="did:xrpl:x")
+        assert r.success is False
+
+    @pytest.mark.asyncio
+    async def test_tracked(self, transport):
+        await transport.submit_did_set("sFAKE", uri="did:xrpl:player1")
+        did = await transport.get_did("rANY")
+        assert did is not None
+        assert did.uri == "did:xrpl:player1"
+
+
+class TestDIDActions:
+    @pytest.mark.asyncio
+    async def test_set_and_verify(self, transport):
+        await set_did(transport, "sFAKE", uri="did:xrpl:player1")
+        v = await verify_did(transport, "rANY", expected_uri="did:xrpl:player1")
+        assert v.found and v.passed
+        assert v.did is not None and v.did.uri == "did:xrpl:player1"
+
+    @pytest.mark.asyncio
+    async def test_verify_none(self, transport):
+        v = await verify_did(transport, "rEMPTY")
+        assert not v.found and not v.passed
+
+    @pytest.mark.asyncio
+    async def test_verify_uri_mismatch(self, transport):
+        await set_did(transport, "sFAKE", uri="did:xrpl:a")
+        v = await verify_did(transport, "rANY", expected_uri="did:xrpl:b")
+        assert not v.passed
+
+
+class TestDIDModule:
+    def test_lints_clean(self):
+        issues = lint_module_file(Path(__file__).parent.parent / "modules" / "did_101.md")
+        assert not [i for i in issues if i.level == "error"]

--- a/tests/test_escrow.py
+++ b/tests/test_escrow.py
@@ -1,0 +1,58 @@
+"""Tests for escrow transport, actions, and the escrow_101 module."""
+
+from pathlib import Path
+
+import pytest
+
+from xrpl_lab.actions.escrow import create_escrow, verify_escrow
+from xrpl_lab.linter import lint_module_file
+from xrpl_lab.transport.dry_run import DryRunTransport
+
+FINISH = 900000000  # arbitrary ripple-epoch time for offline tests
+
+
+@pytest.fixture
+def transport():
+    return DryRunTransport()
+
+
+class TestEscrowTransport:
+    @pytest.mark.asyncio
+    async def test_create_success(self, transport):
+        r = await transport.submit_escrow_create("sFAKE", "10", "rDEST", finish_after=FINISH)
+        assert r.success is True
+        assert r.txid != ""
+
+    @pytest.mark.asyncio
+    async def test_create_fail(self, transport):
+        transport.set_fail_next()
+        r = await transport.submit_escrow_create("sFAKE", "10", "rDEST", finish_after=FINISH)
+        assert r.success is False
+
+    @pytest.mark.asyncio
+    async def test_tracked(self, transport):
+        await transport.submit_escrow_create("sFAKE", "10", "rDEST", finish_after=FINISH)
+        es = await transport.get_escrows("rANY")
+        assert len(es) == 1
+        assert es[0].destination == "rDEST"
+        assert es[0].amount == "10"
+        assert es[0].finish_after == FINISH
+
+
+class TestEscrowActions:
+    @pytest.mark.asyncio
+    async def test_create_and_verify(self, transport):
+        await create_escrow(transport, "sFAKE", "10", "rDEST", FINISH)
+        v = await verify_escrow(transport, "rANY", expected_destination="rDEST")
+        assert v.found and v.passed
+
+    @pytest.mark.asyncio
+    async def test_verify_none(self, transport):
+        v = await verify_escrow(transport, "rEMPTY")
+        assert not v.found and not v.passed
+
+
+class TestEscrowModule:
+    def test_lints_clean(self):
+        issues = lint_module_file(Path(__file__).parent.parent / "modules" / "escrow_101.md")
+        assert not [i for i in issues if i.level == "error"]

--- a/tests/test_mpt.py
+++ b/tests/test_mpt.py
@@ -1,0 +1,67 @@
+"""Tests for MPT transport, actions, and the mpt_issuance_101 module."""
+
+from pathlib import Path
+
+import pytest
+
+from xrpl_lab.actions.mpt import create_mpt_issuance, verify_mpt_issuance
+from xrpl_lab.linter import lint_module_file
+from xrpl_lab.transport.dry_run import DryRunTransport
+
+
+@pytest.fixture
+def transport():
+    return DryRunTransport()
+
+
+class TestMPTTransport:
+    @pytest.mark.asyncio
+    async def test_create_success(self, transport):
+        r = await transport.submit_mpt_issuance_create(
+            "sFAKE", "1000000", asset_scale=2, transfer_fee=500
+        )
+        assert r.success is True
+        assert r.txid != ""
+
+    @pytest.mark.asyncio
+    async def test_create_fail(self, transport):
+        transport.set_fail_next()
+        r = await transport.submit_mpt_issuance_create("sFAKE", "1000000")
+        assert r.success is False
+
+    @pytest.mark.asyncio
+    async def test_tracked(self, transport):
+        await transport.submit_mpt_issuance_create(
+            "sFAKE", "1000000", asset_scale=2, transfer_fee=500
+        )
+        iss = await transport.get_mpt_issuances("rANY")
+        assert len(iss) == 1
+        assert iss[0].maximum_amount == "1000000"
+        assert iss[0].asset_scale == 2
+        assert iss[0].flags & 0x20  # tfMPTCanTransfer
+
+
+class TestMPTActions:
+    @pytest.mark.asyncio
+    async def test_create_and_verify(self, transport):
+        await create_mpt_issuance(transport, "sFAKE", "1000000", asset_scale=2)
+        v = await verify_mpt_issuance(transport, "rANY", expected_maximum="1000000")
+        assert v.found and v.passed
+        assert v.issuance is not None and v.issuance.maximum_amount == "1000000"
+
+    @pytest.mark.asyncio
+    async def test_verify_none(self, transport):
+        v = await verify_mpt_issuance(transport, "rEMPTY")
+        assert not v.found and not v.passed
+
+    @pytest.mark.asyncio
+    async def test_verify_max_mismatch(self, transport):
+        await create_mpt_issuance(transport, "sFAKE", "1000000")
+        v = await verify_mpt_issuance(transport, "rANY", expected_maximum="999")
+        assert not v.passed
+
+
+class TestMPTModule:
+    def test_lints_clean(self):
+        issues = lint_module_file(Path(__file__).parent.parent / "modules" / "mpt_issuance_101.md")
+        assert not [i for i in issues if i.level == "error"]

--- a/xrpl_lab/actions/did.py
+++ b/xrpl_lab/actions/did.py
@@ -1,0 +1,55 @@
+"""DID actions — set a Decentralized Identifier and verify it on-ledger (XLS-40)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..transport.base import DIDInfo, SubmitResult, Transport
+
+
+async def set_did(
+    transport: Transport,
+    wallet_seed: str,
+    uri: str = "",
+    data: str = "",
+) -> SubmitResult:
+    """Create or update the account's DID (DIDSet)."""
+    return await transport.submit_did_set(wallet_seed, uri, data)
+
+
+@dataclass
+class DIDVerifyResult:
+    """Result of verifying a DID on-ledger."""
+
+    found: bool
+    did: DIDInfo | None
+    checks: list[str]
+    failures: list[str]
+
+    @property
+    def passed(self) -> bool:
+        return len(self.failures) == 0
+
+
+async def verify_did(
+    transport: Transport,
+    address: str,
+    expected_uri: str | None = None,
+) -> DIDVerifyResult:
+    """Verify the account has a DID (optionally matching a URI)."""
+    did = await transport.get_did(address)
+    checks: list[str] = []
+    failures: list[str] = []
+    if did is None:
+        failures.append("No DID found for this account")
+        return DIDVerifyResult(False, None, checks, failures)
+
+    checks.append(f"DID found for {did.account[:16]}...")
+    if did.uri:
+        checks.append(f"URI: {did.uri}")
+    if did.data:
+        checks.append(f"Data: {did.data}")
+
+    if expected_uri and did.uri != expected_uri:
+        failures.append(f"URI mismatch: expected {expected_uri}, got {did.uri}")
+    return DIDVerifyResult(True, did, checks, failures)

--- a/xrpl_lab/actions/escrow.py
+++ b/xrpl_lab/actions/escrow.py
@@ -1,0 +1,63 @@
+"""Escrow actions — create a time-based XRP escrow and verify it on-ledger."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..transport.base import EscrowInfo, SubmitResult, Transport
+
+
+async def create_escrow(
+    transport: Transport,
+    wallet_seed: str,
+    amount: str,
+    destination: str,
+    finish_after: int,
+    cancel_after: int | None = None,
+) -> SubmitResult:
+    """Create a time-based XRP escrow (EscrowCreate)."""
+    return await transport.submit_escrow_create(
+        wallet_seed, amount, destination, finish_after, cancel_after
+    )
+
+
+@dataclass
+class EscrowVerifyResult:
+    """Result of verifying an escrow on-ledger."""
+
+    found: bool
+    escrow: EscrowInfo | None
+    checks: list[str]
+    failures: list[str]
+
+    @property
+    def passed(self) -> bool:
+        return len(self.failures) == 0
+
+
+async def verify_escrow(
+    transport: Transport,
+    address: str,
+    expected_destination: str | None = None,
+) -> EscrowVerifyResult:
+    """Verify the account owns an escrow (optionally to a given destination)."""
+    escrows = await transport.get_escrows(address)
+    checks: list[str] = []
+    failures: list[str] = []
+    if not escrows:
+        failures.append("No escrows found for this account")
+        return EscrowVerifyResult(False, None, checks, failures)
+
+    match = escrows[-1]
+    if expected_destination:
+        match = next((e for e in escrows if e.destination == expected_destination), match)
+
+    checks.append(f"Escrow found: {match.amount} drops -> {match.destination[:16]}...")
+    if match.finish_after:
+        checks.append(f"FinishAfter (ripple time): {match.finish_after}")
+    if match.cancel_after:
+        checks.append(f"CancelAfter (ripple time): {match.cancel_after}")
+
+    if expected_destination and match.destination != expected_destination:
+        failures.append(f"Destination mismatch: expected {expected_destination}")
+    return EscrowVerifyResult(True, match, checks, failures)

--- a/xrpl_lab/actions/mpt.py
+++ b/xrpl_lab/actions/mpt.py
@@ -1,0 +1,63 @@
+"""MPT actions — create a Multi-Purpose Token issuance and verify it on-ledger (XLS-33)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..transport.base import MPTIssuanceInfo, SubmitResult, Transport
+
+
+async def create_mpt_issuance(
+    transport: Transport,
+    wallet_seed: str,
+    maximum_amount: str,
+    asset_scale: int = 0,
+    transfer_fee: int = 0,
+    can_transfer: bool = True,
+) -> SubmitResult:
+    """Create a Multi-Purpose Token issuance (MPTokenIssuanceCreate)."""
+    return await transport.submit_mpt_issuance_create(
+        wallet_seed, maximum_amount, asset_scale, transfer_fee, can_transfer
+    )
+
+
+@dataclass
+class MPTVerifyResult:
+    """Result of verifying an MPT issuance on-ledger."""
+
+    found: bool
+    issuance: MPTIssuanceInfo | None
+    checks: list[str]
+    failures: list[str]
+
+    @property
+    def passed(self) -> bool:
+        return len(self.failures) == 0
+
+
+async def verify_mpt_issuance(
+    transport: Transport,
+    address: str,
+    expected_maximum: str | None = None,
+) -> MPTVerifyResult:
+    """Verify the account created an MPT issuance (optionally with a given max supply)."""
+    issuances = await transport.get_mpt_issuances(address)
+    checks: list[str] = []
+    failures: list[str] = []
+    if not issuances:
+        failures.append("No MPT issuances found for this account")
+        return MPTVerifyResult(False, None, checks, failures)
+
+    match = issuances[-1]
+    checks.append(f"MPT issuance found: {match.issuance_id[:24]}...")
+    checks.append(f"Maximum supply: {match.maximum_amount}")
+    checks.append(f"Asset scale: {match.asset_scale}")
+    checks.append(f"Transferable: {'yes' if match.flags & 0x20 else 'no'}")
+    if match.transfer_fee:
+        checks.append(f"Transfer fee: {match.transfer_fee / 1000:.3f}%")
+
+    if expected_maximum is not None and match.maximum_amount != str(expected_maximum):
+        failures.append(
+            f"Max supply mismatch: expected {expected_maximum}, got {match.maximum_amount}"
+        )
+    return MPTVerifyResult(True, match, checks, failures)

--- a/xrpl_lab/curriculum.py
+++ b/xrpl_lab/curriculum.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass, field
 from .modules import ModuleDef
 
 # Canonical tracks in display order.
-TRACKS = ("foundations", "nfts", "dex", "reserves", "audit", "amm")
+TRACKS = (
+    "foundations", "nfts", "tokens", "payments", "identity",
+    "dex", "reserves", "audit", "amm",
+)
 
 # Canonical levels in progression order.
 LEVELS = ("beginner", "intermediate", "advanced")

--- a/xrpl_lab/handlers.py
+++ b/xrpl_lab/handlers.py
@@ -28,6 +28,9 @@ from .actions.dex import (
     verify_offer_absent,
     verify_offer_present,
 )
+from .actions.did import set_did, verify_did
+from .actions.escrow import create_escrow, verify_escrow
+from .actions.mpt import create_mpt_issuance, verify_mpt_issuance
 from .actions.nft import mint_nft, verify_nft
 from .actions.reserves import (
     _drops_to_xrp,
@@ -1738,6 +1741,173 @@ async def handle_verify_nft(
     return context
 
 
+_RIPPLE_EPOCH = 946684800  # seconds between Unix epoch and Ripple epoch (2000-01-01)
+
+
+def _record_submit(state: LabState, context: dict, result) -> None:
+    """Record a submission outcome to state + context (shared by the create handlers)."""
+    if result.success:
+        state.record_tx(
+            txid=result.txid, module_id=context.get("module_id", ""),
+            network=state.network, success=True, explorer_url=result.explorer_url,
+        )
+        context.setdefault("txids", []).append(result.txid)
+    else:
+        state.record_tx(
+            txid=result.txid or "failed", module_id=context.get("module_id", ""),
+            network=state.network, success=False,
+        )
+    save_state(state)
+
+
+async def handle_create_escrow(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    args = step.action_args
+    amount = args.get("amount", "10")
+    if "wallet_seed" not in context:
+        console.print("  [red]No wallet in context. Run the wallet step first.[/]")
+        return context
+    seed = context["wallet_seed"].get()
+    destination = args.get("destination") or state.wallet_address or ""
+    try:
+        delay = int(args.get("finish_seconds", "120"))
+    except ValueError:
+        delay = 120
+    finish_after = int(time.time()) - _RIPPLE_EPOCH + delay
+    cancel_after = finish_after + 86400
+    console.print(f"  Creating time-based escrow: [cyan]{amount}[/] XRP, finishable in ~{delay}s")
+    result = await create_escrow(transport, seed, amount, destination, finish_after, cancel_after)
+    if result.success:
+        console.print("  [green]Escrow created![/]")
+        console.print(f"  TXID: [cyan]{result.txid}[/]")
+        if result.explorer_url:
+            console.print(f"  Explorer: [blue]{result.explorer_url}[/]")
+    else:
+        console.print(f"  [red]Escrow failed: {result.error}[/]")
+    _record_submit(state, context, result)
+    return context
+
+
+async def handle_verify_escrow(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    address = state.wallet_address or ""
+    if not address:
+        console.print("  [red]No wallet address. Run the wallet step first.[/]")
+        return context
+    result = await verify_escrow(transport, address)
+    for c in result.checks:
+        console.print(f"  [green]{c}[/]")
+    for f in result.failures:
+        console.print(f"  [red]{f}[/]")
+    if result.found and result.passed:
+        console.print("  [green]Escrow verified on-ledger.[/]")
+    context["last_escrow_verify"] = result
+    return context
+
+
+async def handle_set_did(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    args = step.action_args
+    uri = args.get("uri", "did:xrpl:example")
+    data = args.get("data", "")
+    if "wallet_seed" not in context:
+        console.print("  [red]No wallet in context. Run the wallet step first.[/]")
+        return context
+    seed = context["wallet_seed"].get()
+    console.print(f"  Setting DID — uri [cyan]{uri}[/]")
+    result = await set_did(transport, seed, uri, data)
+    if result.success:
+        console.print("  [green]DID set![/]")
+        console.print(f"  TXID: [cyan]{result.txid}[/]")
+        if result.explorer_url:
+            console.print(f"  Explorer: [blue]{result.explorer_url}[/]")
+        context["did_uri"] = uri
+    else:
+        console.print(f"  [red]DIDSet failed: {result.error}[/]")
+    _record_submit(state, context, result)
+    return context
+
+
+async def handle_verify_did(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    address = state.wallet_address or ""
+    if not address:
+        console.print("  [red]No wallet address. Run the wallet step first.[/]")
+        return context
+    result = await verify_did(transport, address, expected_uri=context.get("did_uri"))
+    for c in result.checks:
+        console.print(f"  [green]{c}[/]")
+    for f in result.failures:
+        console.print(f"  [red]{f}[/]")
+    if result.found and result.passed:
+        console.print("  [green]DID verified on-ledger.[/]")
+    context["last_did_verify"] = result
+    return context
+
+
+async def handle_create_mpt_issuance(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    args = step.action_args
+    maximum_amount = args.get("maximum_amount", "1000000")
+    try:
+        asset_scale = int(args.get("asset_scale", "0"))
+    except ValueError:
+        asset_scale = 0
+    try:
+        transfer_fee = int(args.get("transfer_fee", "0"))
+    except ValueError:
+        transfer_fee = 0
+    transferable = str(args.get("transferable", "true")).lower() != "false"
+    if "wallet_seed" not in context:
+        console.print("  [red]No wallet in context. Run the wallet step first.[/]")
+        return context
+    seed = context["wallet_seed"].get()
+    console.print(f"  Creating MPT issuance — max supply [cyan]{maximum_amount}[/], "
+                  f"scale [cyan]{asset_scale}[/], transferable [cyan]{transferable}[/]")
+    result = await create_mpt_issuance(
+        transport, seed, maximum_amount, asset_scale, transfer_fee, transferable
+    )
+    if result.success:
+        console.print("  [green]MPT issuance created![/]")
+        console.print(f"  TXID: [cyan]{result.txid}[/]")
+        if result.explorer_url:
+            console.print(f"  Explorer: [blue]{result.explorer_url}[/]")
+        context["mpt_max"] = str(maximum_amount)
+    else:
+        console.print(f"  [red]MPT issuance failed: {result.error}[/]")
+    _record_submit(state, context, result)
+    return context
+
+
+async def handle_verify_mpt_issuance(
+    step: ModuleStep, state: LabState, transport: Transport,
+    wallet_seed: str, context: dict, console: Console,
+) -> dict:
+    address = state.wallet_address or ""
+    if not address:
+        console.print("  [red]No wallet address. Run the wallet step first.[/]")
+        return context
+    result = await verify_mpt_issuance(transport, address, expected_maximum=context.get("mpt_max"))
+    for c in result.checks:
+        console.print(f"  [green]{c}[/]")
+    for f in result.failures:
+        console.print(f"  [red]{f}[/]")
+    if result.found and result.passed:
+        console.print("  [green]MPT issuance verified on-ledger.[/]")
+    context["last_mpt_verify"] = result
+    return context
+
+
 # ---------------------------------------------------------------------------
 # Registration — populate the registry
 # ---------------------------------------------------------------------------
@@ -1802,6 +1972,57 @@ def _register_all() -> None:
             name="verify_nft",
             handler=handle_verify_nft,
             description="Verify NFToken ownership on-ledger",
+        ),
+        ActionDef(
+            name="create_escrow",
+            handler=handle_create_escrow,
+            description="Create a time-based XRP escrow",
+            wallet_required=True,
+            payload_fields=[
+                PayloadField(name="amount", default="10", description="XRP to escrow"),
+                PayloadField(name="destination", description="Recipient (defaults to self)"),
+                PayloadField(name="finish_seconds", type="int", default="120",
+                             description="Seconds until the escrow becomes finishable"),
+            ],
+        ),
+        ActionDef(
+            name="verify_escrow",
+            handler=handle_verify_escrow,
+            description="Verify an escrow exists on-ledger",
+        ),
+        ActionDef(
+            name="set_did",
+            handler=handle_set_did,
+            description="Set a Decentralized Identifier (DIDSet)",
+            wallet_required=True,
+            payload_fields=[
+                PayloadField(name="uri", default="did:xrpl:example", description="DID URI"),
+                PayloadField(name="data", description="Optional DID data"),
+            ],
+        ),
+        ActionDef(
+            name="verify_did",
+            handler=handle_verify_did,
+            description="Verify the account's DID on-ledger",
+        ),
+        ActionDef(
+            name="create_mpt_issuance",
+            handler=handle_create_mpt_issuance,
+            description="Create a Multi-Purpose Token issuance",
+            wallet_required=True,
+            payload_fields=[
+                PayloadField(name="maximum_amount", default="1000000", description="Max supply"),
+                PayloadField(name="asset_scale", type="int", default="0", description="Decimals"),
+                PayloadField(name="transfer_fee", type="int", default="0",
+                             description="Royalty 0-50000; needs transferable"),
+                PayloadField(name="transferable", type="bool", default="true",
+                             description="Whether holders can transfer"),
+            ],
+        ),
+        ActionDef(
+            name="verify_mpt_issuance",
+            handler=handle_verify_mpt_issuance,
+            description="Verify an MPT issuance on-ledger",
         ),
         ActionDef(
             name="create_issuer_wallet",

--- a/xrpl_lab/transport/base.py
+++ b/xrpl_lab/transport/base.py
@@ -93,6 +93,40 @@ class NFTInfo:
 
 
 @dataclass
+class EscrowInfo:
+    """A single Escrow object owned by an account."""
+
+    sequence: int = 0  # the EscrowCreate tx sequence (needed to finish)
+    amount: str = "0"  # XRP drops (or token amount)
+    destination: str = ""
+    finish_after: int | None = None  # ripple-epoch seconds
+    cancel_after: int | None = None
+    condition: str = ""
+
+
+@dataclass
+class DIDInfo:
+    """The DID ledger object for an account (one per account)."""
+
+    account: str
+    uri: str = ""  # decoded UTF-8 if possible, else hex
+    data: str = ""
+    did_document: str = ""
+
+
+@dataclass
+class MPTIssuanceInfo:
+    """A Multi-Purpose Token issuance created by an account."""
+
+    issuance_id: str = ""
+    maximum_amount: str = "0"
+    asset_scale: int = 0
+    transfer_fee: int = 0
+    flags: int = 0
+    outstanding_amount: str = "0"
+
+
+@dataclass
 class AccountSnapshot:
     """Account state at a point in time — balance, owner count, reserves."""
 
@@ -293,3 +327,46 @@ class Transport(ABC):
     @abstractmethod
     async def get_account_nfts(self, address: str) -> list[NFTInfo]:
         """List NFTokens owned by an address (account_nfts)."""
+
+    @abstractmethod
+    async def submit_escrow_create(
+        self,
+        wallet_seed: str,
+        amount: str,
+        destination: str,
+        finish_after: int,
+        cancel_after: int | None = None,
+    ) -> SubmitResult:
+        """Create a time-based XRP Escrow (EscrowCreate)."""
+
+    @abstractmethod
+    async def get_escrows(self, address: str) -> list[EscrowInfo]:
+        """List Escrow objects owned by an address."""
+
+    @abstractmethod
+    async def submit_did_set(
+        self,
+        wallet_seed: str,
+        uri: str = "",
+        data: str = "",
+    ) -> SubmitResult:
+        """Set (create or update) the account's DID (DIDSet)."""
+
+    @abstractmethod
+    async def get_did(self, address: str) -> DIDInfo | None:
+        """Get the account's DID object, or None."""
+
+    @abstractmethod
+    async def submit_mpt_issuance_create(
+        self,
+        wallet_seed: str,
+        maximum_amount: str,
+        asset_scale: int = 0,
+        transfer_fee: int = 0,
+        can_transfer: bool = True,
+    ) -> SubmitResult:
+        """Create a Multi-Purpose Token issuance (MPTokenIssuanceCreate)."""
+
+    @abstractmethod
+    async def get_mpt_issuances(self, address: str) -> list[MPTIssuanceInfo]:
+        """List MPT issuances created by an address."""

--- a/xrpl_lab/transport/dry_run.py
+++ b/xrpl_lab/transport/dry_run.py
@@ -9,7 +9,10 @@ from decimal import ROUND_HALF_UP, Decimal, getcontext
 from .base import (
     AccountSnapshot,
     AmmInfo,
+    DIDInfo,
+    EscrowInfo,
     FundResult,
+    MPTIssuanceInfo,
     NetworkInfo,
     NFTInfo,
     OfferInfo,
@@ -98,6 +101,10 @@ class DryRunTransport(Transport):
         self._lp_balances: dict[str, dict[str, str]] = {}  # address -> {lp_key: balance}
         # NFT state — minted NFTokens per owner address
         self._nfts: _PerAddressStore = _PerAddressStore()
+        # Escrow / DID / MPT state
+        self._escrows: _PerAddressStore = _PerAddressStore()
+        self._mpts: _PerAddressStore = _PerAddressStore()
+        self._dids: dict[str, DIDInfo] = {}  # one DID per account
 
     def _next_txid(self) -> str:
         """Generate a unique deterministic transaction ID (per-instance counter)."""
@@ -919,3 +926,88 @@ class DryRunTransport(Transport):
         if len(real) == 1:
             return list(next(iter(real.values())))
         return []
+
+    # ── Escrow / DID / MPT methods ───────────────────────────────────
+
+    @staticmethod
+    def _resolve(store: _PerAddressStore, address: str) -> list:
+        """Per-address fetch with the legacy + single-wallet fallbacks (shared shape)."""
+        if address in store:
+            return list(store[address])
+        legacy = store.get(_PerAddressStore._LEGACY_KEY, [])
+        if legacy:
+            return list(legacy)
+        real = {k: v for k, v in store.items() if k != _PerAddressStore._LEGACY_KEY}
+        if len(real) == 1:
+            return list(next(iter(real.values())))
+        return []
+
+    async def submit_escrow_create(
+        self,
+        wallet_seed: str,
+        amount: str,
+        destination: str,
+        finish_after: int,
+        cancel_after: int | None = None,
+    ) -> SubmitResult:
+        if self._fail_next:
+            self._fail_next = False
+            return SubmitResult(success=False, result_code="tecNO_PERMISSION", fee="12",
+                                error="[dry-run] Simulated failure: escrow create")
+        owner = _address_from_seed(wallet_seed)
+        txid = self._next_txid()
+        self._escrows.setdefault(owner, []).append(
+            EscrowInfo(sequence=1000 + self._counter, amount=amount, destination=destination,
+                       finish_after=finish_after, cancel_after=cancel_after)
+        )
+        self._owner_count += 1
+        return SubmitResult(success=True, txid=txid, result_code="tesSUCCESS", fee="12",
+                            ledger_index=99999999, explorer_url="")
+
+    async def get_escrows(self, address: str) -> list[EscrowInfo]:
+        return self._resolve(self._escrows, address)
+
+    async def submit_did_set(self, wallet_seed: str, uri: str = "", data: str = "") -> SubmitResult:
+        if self._fail_next:
+            self._fail_next = False
+            return SubmitResult(success=False, result_code="temEMPTY_DID", fee="12",
+                                error="[dry-run] Simulated failure: DID set")
+        owner = _address_from_seed(wallet_seed)
+        if owner not in self._dids:
+            self._owner_count += 1
+        self._dids[owner] = DIDInfo(account=owner, uri=uri, data=data)
+        return SubmitResult(success=True, txid=self._next_txid(), result_code="tesSUCCESS",
+                            fee="12", ledger_index=99999999, explorer_url="")
+
+    async def get_did(self, address: str) -> DIDInfo | None:
+        if address in self._dids:
+            return self._dids[address]
+        if len(self._dids) == 1:
+            return next(iter(self._dids.values()))
+        return None
+
+    async def submit_mpt_issuance_create(
+        self,
+        wallet_seed: str,
+        maximum_amount: str,
+        asset_scale: int = 0,
+        transfer_fee: int = 0,
+        can_transfer: bool = True,
+    ) -> SubmitResult:
+        if self._fail_next:
+            self._fail_next = False
+            return SubmitResult(success=False, result_code="temMALFORMED", fee="12",
+                                error="[dry-run] Simulated failure: MPT issuance create")
+        owner = _address_from_seed(wallet_seed)
+        txid = self._next_txid()
+        iid = hashlib.sha256(f"{owner}-mpt-{self._counter}".encode()).hexdigest().upper()[:48]
+        self._mpts.setdefault(owner, []).append(
+            MPTIssuanceInfo(issuance_id=iid, maximum_amount=maximum_amount, asset_scale=asset_scale,
+                            transfer_fee=transfer_fee, flags=0x20 if can_transfer else 0)
+        )
+        self._owner_count += 1
+        return SubmitResult(success=True, txid=txid, result_code="tesSUCCESS", fee="12",
+                            ledger_index=99999999, explorer_url="")
+
+    async def get_mpt_issuances(self, address: str) -> list[MPTIssuanceInfo]:
+        return self._resolve(self._mpts, address)

--- a/xrpl_lab/transport/xrpl_testnet.py
+++ b/xrpl_lab/transport/xrpl_testnet.py
@@ -16,9 +16,13 @@ from xrpl.models import (
     AccountInfo,
     AccountLines,
     AccountNFTs,
+    AccountObjects,
     AccountOffers,
+    DIDSet,
+    EscrowCreate,
     IssuedCurrencyAmount,
     Memo,
+    MPTokenIssuanceCreate,
     NFTokenMint,
     OfferCancel,
     OfferCreate,
@@ -32,7 +36,10 @@ from xrpl.wallet import Wallet
 from .base import (
     AccountSnapshot,
     AmmInfo,
+    DIDInfo,
+    EscrowInfo,
     FundResult,
+    MPTIssuanceInfo,
     NetworkInfo,
     NFTInfo,
     OfferInfo,
@@ -806,6 +813,187 @@ class XRPLTestnetTransport(Transport):
         except Exception:
             logger.warning("get_account_nfts failed for %s", address, exc_info=True)
             return []
+
+    async def _submit_tx(self, tx, wallet, label: str) -> SubmitResult:
+        """Submit a built+signed transaction with retry/timeout, returning a parsed SubmitResult."""
+        last_error = ""
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                async with _rpc_client(self._rpc_url) as client:
+                    response = await asyncio.wait_for(
+                        submit_and_wait(tx, client, wallet),
+                        timeout=SUBMIT_TIMEOUT,
+                    )
+                result = response.result
+                meta = result.get("meta", {})
+                result_code = meta.get(
+                    "TransactionResult", result.get("engine_result", "unknown")
+                )
+                txid = result.get("hash", "")
+                fee = result.get("Fee", "0")
+                ledger_idx = result.get("ledger_index") or meta.get("ledger_index")
+                success = result_code == "tesSUCCESS"
+                error_msg = ""
+                if not success:
+                    from ..doctor import explain_result_code
+
+                    info = explain_result_code(result_code)
+                    error_msg = f"{info['meaning']}. {info['action']}"
+                return SubmitResult(
+                    success=success, txid=txid, result_code=result_code, fee=fee,
+                    ledger_index=ledger_idx, explorer_url=self._explorer_url(txid), error=error_msg,
+                )
+            except TimeoutError:
+                last_error = f"{label} submission timed out. Try again in a minute."
+                if attempt < MAX_RETRIES:
+                    await asyncio.sleep(RETRY_DELAY)
+                    continue
+            except Exception as exc:
+                last_error = _friendly_error(exc)
+                if any(c in last_error for c in ("temBAD", "tefBAD", "Invalid", "malformed")):
+                    break
+                if attempt < MAX_RETRIES:
+                    await asyncio.sleep(RETRY_DELAY)
+                    continue
+        return SubmitResult(success=False, result_code="local_error", error=last_error)
+
+    async def _account_objects(self, address: str) -> list[dict]:
+        async with _rpc_client(self._rpc_url) as client:
+            resp = await asyncio.wait_for(
+                client.request(AccountObjects(account=address, ledger_index="validated")),
+                timeout=RPC_TIMEOUT,
+            )
+        return resp.result.get("account_objects", [])
+
+    async def submit_escrow_create(
+        self,
+        wallet_seed: str,
+        amount: str,
+        destination: str,
+        finish_after: int,
+        cancel_after: int | None = None,
+    ) -> SubmitResult:
+        guard = self._network_guard()
+        if guard is not None:
+            return SubmitResult(success=False, result_code="local_error", error=guard)
+        try:
+            wallet = Wallet.from_seed(wallet_seed)
+            tx = EscrowCreate(
+                account=wallet.address,
+                amount=xrp_to_drops(Decimal(amount)),
+                destination=destination,
+                finish_after=finish_after,
+                cancel_after=cancel_after,
+            )
+        except Exception as exc:
+            return SubmitResult(
+                success=False, result_code="local_error", error=_friendly_error(exc)
+            )
+        return await self._submit_tx(tx, wallet, "EscrowCreate")
+
+    async def get_escrows(self, address: str) -> list[EscrowInfo]:
+        try:
+            objs = await self._account_objects(address)
+        except Exception:
+            logger.warning("get_escrows failed for %s", address, exc_info=True)
+            return []
+        out: list[EscrowInfo] = []
+        for o in objs:
+            if o.get("LedgerEntryType") != "Escrow":
+                continue
+            out.append(EscrowInfo(
+                amount=str(o.get("Amount", "0")),
+                destination=o.get("Destination", ""),
+                finish_after=o.get("FinishAfter"),
+                cancel_after=o.get("CancelAfter"),
+                condition=o.get("Condition", "") or "",
+            ))
+        return out
+
+    async def submit_did_set(self, wallet_seed: str, uri: str = "", data: str = "") -> SubmitResult:
+        guard = self._network_guard()
+        if guard is not None:
+            return SubmitResult(success=False, result_code="local_error", error=guard)
+        try:
+            wallet = Wallet.from_seed(wallet_seed)
+            tx = DIDSet(
+                account=wallet.address,
+                uri=str_to_hex(uri) if uri else None,
+                data=str_to_hex(data) if data else None,
+            )
+        except Exception as exc:
+            return SubmitResult(
+                success=False, result_code="local_error", error=_friendly_error(exc)
+            )
+        return await self._submit_tx(tx, wallet, "DIDSet")
+
+    async def get_did(self, address: str) -> DIDInfo | None:
+        try:
+            objs = await self._account_objects(address)
+        except Exception:
+            logger.warning("get_did failed for %s", address, exc_info=True)
+            return None
+        for o in objs:
+            if o.get("LedgerEntryType") != "DID":
+                continue
+            def _dec(h):
+                try:
+                    return hex_to_str(h) if h else ""
+                except Exception:
+                    return h or ""
+            return DIDInfo(
+                account=address,
+                uri=_dec(o.get("URI", "")),
+                data=_dec(o.get("Data", "")),
+                did_document=o.get("DIDDocument", "") or "",
+            )
+        return None
+
+    async def submit_mpt_issuance_create(
+        self,
+        wallet_seed: str,
+        maximum_amount: str,
+        asset_scale: int = 0,
+        transfer_fee: int = 0,
+        can_transfer: bool = True,
+    ) -> SubmitResult:
+        guard = self._network_guard()
+        if guard is not None:
+            return SubmitResult(success=False, result_code="local_error", error=guard)
+        try:
+            wallet = Wallet.from_seed(wallet_seed)
+            tx = MPTokenIssuanceCreate(
+                account=wallet.address,
+                maximum_amount=str(maximum_amount),
+                asset_scale=asset_scale or None,
+                transfer_fee=transfer_fee or None,
+                flags=0x20 if can_transfer else 0,  # tfMPTCanTransfer
+            )
+        except Exception as exc:
+            return SubmitResult(
+                success=False, result_code="local_error", error=_friendly_error(exc)
+            )
+        return await self._submit_tx(tx, wallet, "MPTokenIssuanceCreate")
+
+    async def get_mpt_issuances(self, address: str) -> list[MPTIssuanceInfo]:
+        try:
+            objs = await self._account_objects(address)
+        except Exception:
+            logger.warning("get_mpt_issuances failed for %s", address, exc_info=True)
+            return []
+        out: list[MPTIssuanceInfo] = []
+        for o in objs:
+            if o.get("LedgerEntryType") != "MPTokenIssuance":
+                continue
+            out.append(MPTIssuanceInfo(
+                issuance_id=o.get("mpt_issuance_id") or o.get("MPTokenIssuanceID", ""),
+                maximum_amount=str(o.get("MaximumAmount", "0")),
+                asset_scale=int(o.get("AssetScale", 0) or 0),
+                transfer_fee=int(o.get("TransferFee", 0) or 0),
+                flags=int(o.get("Flags", 0) or 0),
+                outstanding_amount=str(o.get("OutstandingAmount", "0")),
+            ))
+        return out
 
     def _amount_obj(
         self, currency: str, value: str, issuer: str


### PR DESCRIPTION
Three more KB-sourced modules end-to-end, extending xrpl-lab into the depth the coverage-gap analysis flagged. Builds on the NFT module + transport fix (PR #4).

## New modules & tracks
- **`mpt_issuance_101`** (track **tokens**) — issue a Multi-Purpose Token (XLS-33) game currency in one tx.
- **`escrow_101`** (track **payments**) — lock XRP in a time-based escrow.
- **`did_101`** (track **identity**) — anchor a Decentralized Identifier (XLS-40).

## Stack (per module)
- Transport: `EscrowInfo` / `DIDInfo` / `MPTIssuanceInfo` + submit/get pairs on the `Transport` ABC, in **both** `DryRunTransport` (offline) and `XRPLTestnetTransport` (real `EscrowCreate` / `DIDSet` / `MPTokenIssuanceCreate` via xrpl-py; `account_objects` for verification). Adds `_submit_tx` / `_account_objects` helpers.
- `actions/{escrow,did,mpt}.py` (create + verify) → handlers → registered actions.
- Module content seeded from the verified KB, carrying its gotchas: FinishAfter/CancelAfter ordering; off-ledger DID documents; **MPT isn't DEX-tradeable yet (XLS-82)** so use IOU for tradeable currency; hard-vs-soft money.

## Provenance & verification
- Sourced from KB capabilities `escrow-xrp`, `did-transactions`, `mpt-issuance-create-config` (cross-family verified).
- **Full suite: 813 passed** (20 new); `ruff check` clean; module + curriculum lint clean.
- **Verified live on testnet** via the real transport — EscrowCreate, DIDSet, MPTokenIssuanceCreate all `tesSUCCESS` with on-ledger `account_objects` verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)