### PR TITLE
ci: bump Actions to Node 24 (June 16 deprecation)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag || github.event.release.tag_name || github.ref }}
 
-      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - run: uv python install 3.12
 
@@ -116,7 +116,7 @@ jobs:
           sha256sum * > "checksums-${VERSION}.txt"
           cat "checksums-${VERSION}.txt"
 
-      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: artifacts/*
           tag_name: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -95,7 +95,7 @@ jobs:
         # Always upload so a passing run's ledger/txid trace is inspectable too,
         # not just failures. retention is short — this is ephemeral diagnostics.
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoke-log
           path: smoke.log


### PR DESCRIPTION
Bumps 3 Node-20 action pin(s) to their latest Node-24 SHA-pinned releases ahead of GitHub's 2026-06-16 forced-Node-24 cutover.

Actions: actions/upload-artifact, astral-sh/setup-uv, softprops/action-gh-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)