### PR TITLE
fix(release): export TAG_VERSION in the bin-version gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,10 @@ jobs:
       # tests/test_v2_core.py::test_version_matches_pyproject.
       - name: Verify tag matches bin/xrpl-lab.js launch config
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          # export (not a bare shell var) so the child `node` process sees it in
+          # process.env — the shell-var form read undefined in node and false-failed
+          # every real tag push (the local test masked it; CI semantics differ).
+          export TAG_VERSION="${GITHUB_REF_NAME#v}"
           node -e '
             const fs = require("fs");
             const src = fs.readFileSync("bin/xrpl-lab.js", "utf8");


### PR DESCRIPTION
The v2.0.0 tag push failed at the bin/xrpl-lab.js version gate — it read the tag as `undefined` ("Release tag vundefined") because `TAG_VERSION` was a bare shell var while the node child reads `process.env.TAG_VERSION`. Shell vars aren't exported to child processes. **Nothing published** (the gate runs before npm publish / GH release / PyPI / binaries — all skipped).

Fix: `export TAG_VERSION`. Verified locally against the real launch config: green on match (exit 0), red on mismatch (exit 1). After merge, the v2.0.0 tag is re-pushed to re-trigger the (now correct) release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)